### PR TITLE
Improve nslcd management and allow removal

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,7 +109,7 @@ class ldap(
     group   => $ldap::params::group,
   }
 
-  file { "${ldap::params::prefix}":
+  file { $ldap::params::prefix:
     ensure  => directory,
     require => Package[$ldap::params::package],
   }
@@ -117,10 +117,8 @@ class ldap(
   file { "${ldap::params::prefix}/${ldap::params::config}": content => template('ldap/ldap.conf.erb'), }
 
   if $nslcd {
-    if $ldap::params::nslcd_package {
-      package { $ldap::params::nslcd_package: ensure => present, notify => Service['nslcd'] }
-    }
-    file { '/etc/nslcd.conf': content => template('ldap/nslcd.conf.erb'), mode => '0640' }
-    service { 'nslcd': ensure => running, require => File['/etc/nslcd.conf'], }
+    include ldap::nslcd
+  } else {
+    class { '::ldap::nslcd': ensure => absent }
   }
 }

--- a/manifests/nslcd.pp
+++ b/manifests/nslcd.pp
@@ -1,0 +1,40 @@
+class ldap::nslcd (
+  $ensure = 'present',
+) {
+
+  validate_re($ensure, ['present', 'absent'])
+
+  include ldap::params
+
+  $package = $ldap::params::nslcd_package
+  $service = $ldap::params::nslcd_service
+  $conf    = $ldap::params::nslcd_conf #nslcd.conf
+
+  if $ensure == 'present' {
+    if $package {
+      package { $package:
+        ensure => present,
+        notify => Service[$service]
+      }
+    }
+
+    file { $conf:
+      content => template('ldap/nslcd.conf.erb'),
+      mode    => '0640',
+    }
+
+    service { $service:
+      ensure  => running,
+      require => File[$conf],
+    }
+  } elsif $ensure == 'absent' {
+    if $package {
+      package { $package:
+        ensure => absent, }
+    }
+
+    file { $conf:
+      ensure => absent,
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,9 +7,10 @@ class ldap::params {
       $owner         = 'root'
       $group         = 'root'
       $config        = 'ldap.conf'
+      $nslcd_conf    = '/etc/nslcd.conf'
       $nslcd_package = ['nslcd', 'libnss-ldapd']
+      $nslcd_service = 'nslcd'
       $cacert        = '/etc/ssl/certs/ldapcabundle.pem'
-
     }
     default:  {
       fail("Operating system ${::operatingsystem} not supported")


### PR DESCRIPTION
This work implements a class to manage nslcd as its own service and
package.  Here also is an extension to allow the removal of nslcd.  This
should pave the way for swapping out nslcd for sssd.
