### PR TITLE
Begin SSSd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # puppetlabs-ldap
+
+### System Security Services Daemon (sssd)
+
+The [sssd][sssd] daemon provides NSS and PAM modules for retrieving and
+authenticating identities.  It is a more modern approach for the historcal
+`nscd`/`nslcd` daemons.
+
+Using `sssd` with this module is easy.
+
+```Puppet
+class { 'ldap':
+  sssd => true,
+}
+```
+
+
+[sssd]: https://fedorahosted.org/sssd/

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,9 @@
 #
 #  [nslcd]
 #    If you are going to use nslcd. (defaults to false)
+
+#  [sssd]
+#    If you are going to use sssd. (defaults to false)
 #
 # === Examples
 #
@@ -95,6 +98,7 @@ class ldap(
   $nss_group      = false,
   $nss_shadow     = false,
   $nslcd          = false,
+  $sssd           = false,
   $pam_filter     = false,
 ) {
 
@@ -120,5 +124,11 @@ class ldap(
     include ldap::nslcd
   } else {
     class { '::ldap::nslcd': ensure => absent }
+  }
+
+  if $sssd {
+    include ldap::sssd
+  } else {
+    class { '::ldap::sssd': ensure => absent }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,9 @@ class ldap::params {
       $nslcd_conf    = '/etc/nslcd.conf'
       $nslcd_package = ['nslcd', 'libnss-ldapd']
       $nslcd_service = 'nslcd'
+      $sssd_conf     = '/etc/sssd/sssd.conf'
+      $sssd_package  = ['sssd', 'libnss-sss']
+      $sssd_service  = 'sssd'
       $cacert        = '/etc/ssl/certs/ldapcabundle.pem'
     }
     default:  {

--- a/manifests/sssd.pp
+++ b/manifests/sssd.pp
@@ -1,0 +1,49 @@
+class ldap::sssd (
+  $uri,
+  $search_base,
+  $ensure      = 'present',
+  $schema      = 'rfc2307bis', # Use 'member' attribute on group
+  $bind_dn     = undef,
+  $bind_pw     = undef,
+  $filter      = undef,
+  $tls_cacert  = undef,
+  $tls_reqcert = undef,
+) {
+
+  validate_re($ensure, ['present', 'absent'])
+  validate_re($schema, ['rfc2307', 'rfc2307bis'])
+
+  include ldap::params
+
+  $package = $ldap::params::sssd_package
+  $service = $ldap::params::sssd_service
+  $conf    = $ldap::params::sssd_conf #sssd.conf
+
+  if $ensure == 'present' {
+    if $package {
+      package { $package:
+        ensure => present,
+        notify => Service[$service]
+      }
+    }
+
+    file { $conf:
+      content => template('ldap/sssd.conf.erb'),
+      mode    => '0600',
+    }
+
+    service { $service:
+      ensure  => running,
+      require => File[$conf],
+    }
+  } elsif $ensure == 'absent' {
+    if $package {
+      package { $package:
+        ensure => absent, }
+    }
+
+    file { $conf:
+      ensure => absent,
+    }
+  }
+}

--- a/templates/sssd.conf.erb
+++ b/templates/sssd.conf.erb
@@ -1,0 +1,47 @@
+[sssd]
+config_file_version = 2
+services = nss, pam
+# SSSD will not start if you do not configure any domains.
+# Add new domain configurations as [domain/<NAME>] sections, and
+# then add the list of domains (in the order you want them to be
+# queried) to the "domains" attribute below and uncomment it.
+domains = LDAP
+
+[nss]
+
+[pam]
+
+# Example LDAP domain
+[domain/LDAP]
+id_provider = ldap
+auth_provider = ldap
+# ldap_schema can be set to "rfc2307", which stores group member names in the
+# "memberuid" attribute, or to "rfc2307bis", which stores group member DNs in
+# the "member" attribute. If you do not know this value, ask your LDAP
+# administrator.
+ldap_schema = <%= @schema %>
+ldap_uri = <%= @uri %>
+ldap_search_base = <%= @search_base %>
+# Note that enabling enumeration will have a moderate performance impact.
+# Consequently, the default value for enumeration is FALSE.
+# Refer to the sssd.conf man page for full details.
+; enumerate = false
+# Allow offline logins by locally storing password hashes (default: false).
+; cache_credentials = true
+
+<% if @bind_dn -%>
+ldap_default_bind_dn = <%= @bind_dn %>
+<% end -%>
+<% if @bind_pw -%>
+ldap_default_authtok = <%= @bind_pw %>
+<% end -%>
+<% if @filter -%>
+ldap_access_filter = <%= @filter %>
+<% end -%>
+<% if @tls_cacert -%>
+ldap_tls_cacert = <%= @tls_cacert %>
+<% end -%>
+<% if @tls_reqcert -%>
+ldap_tls_reqcert = <%= @tls_reqcert %>
+<% end -%>
+


### PR DESCRIPTION
This work mirrors that of the nslcd work and adds suport to sssd through
the ldap::sssd class.
