### PR TITLE
Move SSL related parameters to TLS option names

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@
 #
 #  [ssl]
 #    Enable TLS/SSL negotiation with the server
-#    *Requires*: ssl_cert parameter
+#    *Requires*: tls_cacert parameter
 #    *Optional* (defaults to false)
 #
 #  [nsswitch]
@@ -92,7 +92,8 @@ class ldap(
   $binddn         = false,
   $bindpw         = false,
   $ssl            = false,
-  $ssl_reqcert    = 'never',
+  $tls_cacert     = undef,
+  $tls_reqcert    = 'never',
   $nsswitch       = false,
   $nss_passwd     = false,
   $nss_group      = false,

--- a/manifests/nslcd.pp
+++ b/manifests/nslcd.pp
@@ -9,7 +9,8 @@ class ldap::nslcd (
   $bind_timelimit = 30,
   $idle_timelimit = 60,
   $ssl            = false,
-  $ssl_reqcert    = 'never',
+  $tls_cacert     = undef,
+  $tls_reqcert    = 'never',
 ) {
 
   validate_re($ensure, ['present', 'absent'])

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,11 +13,9 @@ class ldap::params {
       $sssd_conf     = '/etc/sssd/sssd.conf'
       $sssd_package  = ['sssd', 'libnss-sss']
       $sssd_service  = 'sssd'
-      $cacert        = '/etc/ssl/certs/ldapcabundle.pem'
     }
     default:  {
       fail("Operating system ${::operatingsystem} not supported")
     }
   }
 }
-

--- a/templates/ldap.conf.erb
+++ b/templates/ldap.conf.erb
@@ -30,8 +30,8 @@ nss_initgroups_ignoreusers root daemon bin sys sync games man lp mail news uucp 
 
 <% if @ssl == true then -%>
 ssl           start_tls
-tls_reqcert   <%= @ssl_reqcert %>
-tls_cacert    <%= scope.lookupvar('ldap::params::cacert') %>
+tls_cacert    <%= @tls_cacert %>
+tls_reqcert   <%= @tls_reqcert %>
 <% end -%>
 
 <% if @filter != false then -%>

--- a/templates/nslcd.conf.erb
+++ b/templates/nslcd.conf.erb
@@ -21,8 +21,8 @@ bindpw <%= @bindpw %>
 
 <% if @ssl == true -%>
 ssl           start_tls
-tls_reqcert    <%= @ssl_reqcert %>
-tls_cacertfile <%= scope.lookupvar('ldap::params::cacert') %>
+tls_reqcert    <%= @tls_reqcert %>
+tls_cacertfile <%= @tls_cacert %>
 <% end -%>
 uid nslcd
 gid nslcd


### PR DESCRIPTION
This should help keep consistency around what options are called
regardless of the component of the system the user is working with.
