### PR TITLE
Reference README for updated documentation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,22 +65,7 @@
 #  [nslcd]
 #    If you are going to use nslcd. (defaults to false)
 
-#  [sssd]
-#    If you are going to use sssd. (defaults to false)
-#
-# === Examples
-#
-# class { 'ldap':
-#	uri  => 'ldap://ldapserver00 ldap://ldapserver01',
-#	base => 'dc=suffix',
-# }
-#
-# class { 'ldap':
-#	uri  => 'ldap://ldapserver00',
-#	base => 'dc=suffix',
-#	ssl  => true,
-#	ssl_cert => 'ldapserver00.pem'
-# }
+# === See README for examples
 #
 class ldap(
   $uri,


### PR DESCRIPTION
Its a pain to have to update docs in two places.  I'd rather just read
teh README and keep the comments clean in the class.

This work points the user to reference the README for examples.
