### PR TITLE
Add FreeBSD support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,19 @@ class ldap::params {
       $sssd_service  = 'sssd'
       $cacert        = '/etc/ssl/certs/ldapcabundle.pem'
     }
+    'FreeBSD': {
+      $package       = 'openldap-client'
+      $prefix        = '/usr/local/etc/openldap'
+      $owner         = 'root'
+      $group         = '0'
+      $config        = 'ldap.conf'
+      $nslcd_conf    = '/usr/local/etc/nslcd.conf'
+      $nslcd_package = 'nss-pam-ldapd'
+      $nslcd_service = 'nslcd'
+      $sssd_conf     = '/usr/local/etc/sssd/sssd.conf'
+      $sssd_package  = 'sssd'
+      $sssd_service  = 'sssd'
+    }
     default:  {
       fail("Operating system ${::operatingsystem} not supported")
     }


### PR DESCRIPTION
This work adds the params necessary to make this module work on FreeBSD.
It has been tested functional on FreeBSD 10.1.
